### PR TITLE
fix(client): make client buildable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "The kickr client app",
   "author": "Kickr Team",
   "devDependencies": {
-    "brfs": "^1.2.0",
+    "brfs": "1.2.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^2.1.4",
     "grunt-contrib-connect": "^0.4.0",


### PR DESCRIPTION
The client is not buildable if brfs is in a version higher than 1.2.0
